### PR TITLE
Removed the cloud icons

### DIFF
--- a/tool/ui.R
+++ b/tool/ui.R
@@ -332,7 +332,7 @@ dashboardPage(title="Openmasses",
                      ),
                      br(),
                      hidden(
-                       downloadButton("logDownload", "Download log", class = "btn-success", icon="cloud")
+                       downloadButton("logDownload", "Download log", class = "btn-success") # , icon="cloud")
                      )
               )
             ),
@@ -531,7 +531,7 @@ dashboardPage(title="Openmasses",
       
     tabPanel("Manual",
       p("an example longlist can be downloaded here"),
-      downloadButton("exampleLongListDownload", "Download Example Longlist", class = "btn-success", icon = "cloud"))
+      downloadButton("exampleLongListDownload", "Download Example Longlist", class = "btn-success")) #, icon = "cloud"))
     ),
   
   # Set tooltips


### PR DESCRIPTION
Two of the downloadButtons were referring to an icon I at least no longer have. These buttons are logDownload and exampleLongListDownload. This only today was a problem so this might not be necessary.